### PR TITLE
Views should still work when Query Params are added to the URL

### DIFF
--- a/index.php
+++ b/index.php
@@ -541,10 +541,20 @@ if ( !function_exists( 'process_view' ) ) {
 	function process_view() {
 		global $config;
 
-		$url    = str_replace( '?' . $_SERVER['QUERY_STRING'], '', $_SERVER['REQUEST_URI'] ); // remove query string
+		$path = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH);
+		$query = parse_url($_SERVER['REQUEST_URI'], PHP_URL_QUERY);
+
+		if ((empty($path) || '/' === $path) && !empty($query)) {
+			$url = $query;
+		}
+		else {
+			$url = $path;
+		}
+
 		$url    = preg_replace( '/\.[^.\s]{2,4}$/', '', $url ); // remove file extension
 		$route  = explode( '/', $url );
 		$action = end( $route );
+
 		if ( $action == '' ) {
 			$action = 'index';
 		}


### PR DESCRIPTION
The current routing method produced `404` when adding query params to valid URLs (e.g. `/home?nocache=true`) as the question mark was simply dropped and a view with the name `valid-viewnocache=true` cannot found.

The changes in this PR use the query string as the action if no path was set (e.g. `/?home`) but completely ignore the query string when a path was set (e.g. `/home?nocache=true`).
